### PR TITLE
Added a llink to the forum thread

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -14,6 +14,7 @@
 		<description lang="en">DR (Danish Broadcasting Corporation) provides a variation of their programming as video and audio podcasts, where typically 5-10 of the latest episodes are available online.[CR][CR]If you have comments or suggestions for this addon, please feel free to participate in the debate on my blog at http://tommy.winther.nu</description>
 		<description lang="da">DR udgiver en række af deres programmer som video og lyd podcasts, hvor typisk de seneste 5-10 afsnit er tilgængelige online.[CR][CR]Har du kommentarer, ris eller ros til denne addon er du velkommen til at deltage i debatten på min blog på http://tommy.winther.nu</description>
 		<license>GPL 2.0</license>
+		<forum>http://forum.kodi.tv/showthread.php?tid=80674</forum>
 		<platform>all</platform>
         <language>da</language>
         <email>tommy@winther.nu</email>


### PR DESCRIPTION
Needed to automatically fill the links on http://kodi.wiki and http://addons.kodi.tv/ sites.
